### PR TITLE
feat: add option to disable spam prevention

### DIFF
--- a/src/services/systemd/tedge-benchmark.service
+++ b/src/services/systemd/tedge-benchmark.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/var/log/tedge-benchmark
-ExecStart=/usr/bin/tedge-benchmark.py run --count 1000 --beats 100 --period 500 --out-metric "tedge-benchmark.prom"
+ExecStart=/usr/bin/tedge-benchmark.py run --count 100 --beats 10 --period 500 --out-metric "tedge-benchmark.prom" --disable-protection
 StandardOutput=append:/var/log/tedge-benchmark/tedge-benchmark.log
 LogsDirectory=tedge-benchmark
 


### PR DESCRIPTION
Support a new flag which will disable the mosquitto bridge protection mechanism which comments out the `measurement/measurements/create` topic from the cloud bridge configuration.

The defaults used in the benchmark service were also reduce to sensible defaults to allow responsible (good citizen) testing against a real cloud.